### PR TITLE
remove FDB entires of BridgePort before removing the BridgePort

### DIFF
--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -47,6 +47,8 @@ public:
     void update(sai_fdb_event_t, const sai_fdb_entry_t *, sai_object_id_t);
     void update(SubjectType type, void *cntx);
     bool getPort(const MacAddress&, uint16_t, Port&);
+    void flushFDBEntries(sai_object_id_t bridge_port_oid,
+                         sai_object_id_t vlan_oid);
 
 private:
     PortsOrch *m_portsOrch;
@@ -64,9 +66,6 @@ private:
     void updatePortOperState(const PortOperStateUpdate&);
     bool addFdbEntry(const FdbEntry&, const string&);
     bool removeFdbEntry(const FdbEntry&);
-    void flushFDBEntries(sai_object_id_t bridge_port_oid,
-                         sai_object_id_t vlan_oid);
-
     bool storeFdbEntryState(const FdbUpdate& update);
 };
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -444,6 +444,16 @@ void PortsOrch::removeDefaultBridgePorts()
         }
         if (attr.value.s32 == SAI_BRIDGE_PORT_TYPE_PORT)
         {
+            Port port;
+	    getPortByBridgePortId(bridge_port_list[i], port);
+
+            //Flush the FDB entires corresponding to the port
+            if (!flushFdbEntries(port))
+            {	    
+                SWSS_LOG_ERROR("Failed to flush FDB entries for port %s",
+                               port.m_alias.c_str());
+            }
+
             status = sai_bridge_api->remove_bridge_port(bridge_port_list[i]);
             if (status != SAI_STATUS_SUCCESS)
             {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3130,7 +3130,7 @@ void PortsOrch::doTask(Consumer &consumer)
     }
 }
 
-bool PortsOrch::flushFDBEntries(sai_object_id_t bridge_port_id)
+bool PortsOrch::flushFdbEntries(Port port)
 {
     vector<sai_attribute_t>    attrs;
     sai_attribute_t            attr;
@@ -3138,23 +3138,23 @@ bool PortsOrch::flushFDBEntries(sai_object_id_t bridge_port_id)
 
     SWSS_LOG_ENTER();
 
-    if (SAI_NULL_OBJECT_ID == bridge_port_id)
+    if (SAI_NULL_OBJECT_ID == port.m_bridge_port_id)
     {
-        SWSS_LOG_WARN("Couldn't flush FDB. Bridge port OID: 0x%" PRIx64,
-                      bridge_port_id);
+        SWSS_LOG_WARN("Couldn't flush FDB entries for port: %s",
+                      port.m_alias.c_str());
         return false;
     }
 
     attr.id = SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID;
-    attr.value.oid = bridge_port_id;
+    attr.value.oid = port.m_bridge_port_id;
     attrs.push_back(attr);
 
-    SWSS_LOG_INFO("Flushing FDB bridge_port_oid: 0x%" PRIx64, bridge_port_id);
+    SWSS_LOG_INFO("Flushing FDB entries for port: %s", port.m_alias.c_str());
 
     rv = sai_fdb_api->flush_fdb_entries(gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (SAI_STATUS_SUCCESS != rv)
     {
-        SWSS_LOG_ERROR("Flushing FDB failed. rv:%d", rv);
+        SWSS_LOG_ERROR("Flushing FDB for port %s failed. rv:%d", port.m_alias.c_str(), rv);
 	return false;
     }
 
@@ -3463,9 +3463,9 @@ bool PortsOrch::removeBridgePort(Port &port)
     }
 
     //Flush the FDB entires corresponding to the port
-    if (!flushFDBEntries(port.m_bridge_port_id))
+    if (!flushFdbEntries(port))
     {	    
-        SWSS_LOG_ERROR("Failed to flush FDB entries for the port %s",
+        SWSS_LOG_ERROR("Failed to flush FDB entries for port %s",
                 port.m_alias.c_str());
         return false;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3155,7 +3155,7 @@ bool PortsOrch::flushFdbEntries(Port port)
     if (SAI_STATUS_SUCCESS != rv)
     {
         SWSS_LOG_ERROR("Flushing FDB for port %s failed. rv:%d", port.m_alias.c_str(), rv);
-	return false;
+        return false;
     }
 
     return true;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -445,13 +445,12 @@ void PortsOrch::removeDefaultBridgePorts()
         if (attr.value.s32 == SAI_BRIDGE_PORT_TYPE_PORT)
         {
             Port port;
-	    getPortByBridgePortId(bridge_port_list[i], port);
+            getPortByBridgePortId(bridge_port_list[i], port);
 
             //Flush the FDB entires corresponding to the port
             if (!flushFdbEntries(port))
             {	    
-                SWSS_LOG_ERROR("Failed to flush FDB entries for port %s",
-                               port.m_alias.c_str());
+                SWSS_LOG_ERROR("Failed to flush FDB entries for port %s", port.m_alias.c_str());
             }
 
             status = sai_bridge_api->remove_bridge_port(bridge_port_list[i]);
@@ -3150,8 +3149,7 @@ bool PortsOrch::flushFdbEntries(Port port)
 
     if (SAI_NULL_OBJECT_ID == port.m_bridge_port_id)
     {
-        SWSS_LOG_WARN("Couldn't flush FDB entries for port: %s",
-                      port.m_alias.c_str());
+        SWSS_LOG_WARN("Couldn't flush FDB entries for port: %s", port.m_alias.c_str());
         return false;
     }
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -127,7 +127,6 @@ public:
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
     void getLagMember(Port &lag, vector<Port> &portv);
-    bool flushFdbEntries(Port);
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -127,7 +127,7 @@ public:
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
     void getLagMember(Port &lag, vector<Port> &portv);
-    bool flushFDBEntries(sai_object_id_t);
+    bool flushFDBEntries(Port);
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -127,6 +127,7 @@ public:
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
     void getLagMember(Port &lag, vector<Port> &portv);
+    bool flushFDBEntries(sai_object_id_t);
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -127,7 +127,7 @@ public:
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
     void getLagMember(Port &lag, vector<Port> &portv);
-    bool flushFDBEntries(Port);
+    bool flushFdbEntries(Port);
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
To fix an issue when removing bridgeport, I introduced code to remove FDB entries of the bridgeport before calling SAI API remove BridgePort.

**Why I did it**
I introduced this fix because by directly removing the bridgeport without flushing the bridge port's FDB entries, the bridge port removal was failing, since it had uncleaned ASIC DB FDB entries.

**How I verified it**
I verified it by sending traffic to the vlan port and creating a FDB entry for the vlan port. By, then when I remove the bridge port member from the VLAN port, the FDB entry was removed as well as bridge port is removed from VLAN membership. 

**Details if related**
The fix is introduced in PortsOrch.cpp